### PR TITLE
removing openshift supported version from messaging topology operator…

### DIFF
--- a/generate_OLM/generate_OLM_messaging_topology_operator/generators/annotations-openshift.yaml
+++ b/generate_OLM/generate_OLM_messaging_topology_operator/generators/annotations-openshift.yaml
@@ -5,4 +5,3 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: rabbitmq-messaging-topology-operator
-  com.redhat.openshift.versions: "v4.7-v4.11"


### PR DESCRIPTION
This line com.redhat.openshift.versions: "v4.7-v4.11" was originally put to avoid deploying on Openshift v4.6.

It appears that nowadays the minimum supported version is 4.10
https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/2905.

So I think we can remove it and see what happen during the next release.

