### PR TITLE
consume metadata.annotations['olm.targetNamespaces'] to allow single/…

### DIFF
--- a/rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-operator-namespace-scope-overlay.yml
+++ b/rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-operator-namespace-scope-overlay.yml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ deployment = overlay.subset({"kind": "Deployment"})
+#@ cluster_operator = overlay.subset({"metadata": {"name": "rabbitmq-cluster-operator"}})
+#@overlay/match by=overlay.and_op(deployment, cluster_operator),expects="1+"
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name": "operator"}),expects="1+"
+      -
+        #@overlay/match missing_ok=True
+        env:
+        - name: OPERATOR_SCOPE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']

--- a/rabbitmq_olm_package_repo/generators/messaging_topology_operator_generators/topology-operator-namespace-scope-overlay.yml
+++ b/rabbitmq_olm_package_repo/generators/messaging_topology_operator_generators/topology-operator-namespace-scope-overlay.yml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ deployment = overlay.subset({"kind": "Deployment"})
+#@ topology_operator = overlay.subset({"metadata": {"name": "messaging-topology-operator"}})
+#@overlay/match by=overlay.and_op(deployment, topology_operator),expects="1+"
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name": "manager"}),expects="1+"
+      -
+        #@overlay/match missing_ok=True
+        env:
+        - name: OPERATOR_SCOPE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']

--- a/rabbitmq_olm_package_repo/main.py
+++ b/rabbitmq_olm_package_repo/main.py
@@ -39,7 +39,12 @@ def main():
         cluster_operator_release_file = (
             "./rabbitmq_olm_package_repo/tmpmanifests/cluster-operator.yaml"
         )
-        os.system("cp " + operator_release_file + " " + cluster_operator_release_file)
+        os.system(
+            "ytt -f "
+            + operator_release_file
+            + " -f ./rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-operator-namespace-scope-overlay.yml > "
+            + cluster_operator_release_file
+        )
         os.system('echo "\n---" >> ' + cluster_operator_release_file)
         create_cluster_operator_bundle(
             cluster_operator_release_file, version, output_directory
@@ -51,11 +56,12 @@ def main():
             "./rabbitmq_olm_package_repo/tmpmanifests/cluster-operator.yaml"
         )
         os.system(
-            "cp "
+            "ytt -f "
             + operator_release_file
-            + " "
+            + " -f ./rabbitmq_olm_package_repo/generators/messaging_topology_operator_generators/topology-operator-namespace-scope-overlay.yml > "
             + messaging_topology_operator_release_file
         )
+
         os.system('echo "\n---" >> ' + messaging_topology_operator_release_file)
         create_messaging_topology_operator_bundle(
             messaging_topology_operator_release_file, version, output_directory


### PR DESCRIPTION
There is actually a bug when we do a single/multiple namespace installation mode.

At the moment we use OPERATOR_SCOPE_NAMESPACE env variable in order to specify the namespaces where the operator will reconcile and watch RabbitmqClusters.

In OLM this is implemented through an operator group (og):
https://docs.openshift.com/container-platform/4.8/operators/understanding/olm/olm-understanding-operatorgroups.html

In order to allow an operator group to work properly the csv needs to consume metadata.annotations['olm.targetNamespaces'] and pass it to our OPERATOR_SCOPE_NAMESPACE env variable.

I have implemented this through ytt as we already use it throughout the code.