### PR TITLE
reverting maintainer field

### DIFF
--- a/rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-service-version-generator-openshift.yml
+++ b/rabbitmq_olm_package_repo/generators/cluster_operator_generators/cluster-service-version-generator-openshift.yml
@@ -30,6 +30,9 @@ spec:
   keywords:
   - rabbitmq
   - messaging
+  maintainers:
+  - name: VMware Tanzu
+    email: rabbitmq-users@googlegroups.com 
   provider:
     name: VMware Tanzu
   labels: {}

--- a/rabbitmq_olm_package_repo/generators/messaging_topology_operator_generators/topology-service-version-generator-openshift.yml
+++ b/rabbitmq_olm_package_repo/generators/messaging_topology_operator_generators/topology-service-version-generator-openshift.yml
@@ -57,6 +57,9 @@ spec:
   keywords:
   - rabbitmq
   - messaging
+  maintainers:
+  - name: VMware Tanzu
+    email: rabbitmq-users@googlegroups.com 
   provider:
     name: 'VMware Tanzu'
   labels: {}


### PR DESCRIPTION
Reverting https://github.com/rabbitmq/OLM-Package-Repo/pull/23

as the maintainer field is necessary in openshift-marketplace:

https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/4649